### PR TITLE
sqlite datatype BOOL is now converted to TINYINT(1) as well

### DIFF
--- a/sqlite3_to_mysql/transporter.py
+++ b/sqlite3_to_mysql/transporter.py
@@ -296,7 +296,7 @@ class SQLite3toMySQL(SQLite3toMySQLAttributes):
                 if "UNSIGNED" in self._mysql_integer_type:
                     return f"{match.group(0).upper()}{length} UNSIGNED"
                 return f"{match.group(0).upper()}{length}{' UNSIGNED' if unsigned else ''}"
-        if data_type == "BOOLEAN":
+        if data_type == "BOOLEAN" or data_type == "BOOL":
             return "TINYINT(1)"
         if data_type.startswith(("REAL", "DOUBLE", "FLOAT", "DECIMAL", "DEC", "FIXED")):
             return full_column_type


### PR DESCRIPTION
## Reason

Some projects (including the Django web framework for example) use "BOOL" as datatype for storing boolean values in their sqlite database.

Using sqlite3-to-mysql as it is to convert such a sqllite database results in a mysql database with the BOOL values stored as text in VARCHAR fields. Which is undesirable, especially concerning fields like auth_user.is_superuser ...   

